### PR TITLE
Fix CLI entrypoint for run_embedding script

### DIFF
--- a/scripts/run_embedding.py
+++ b/scripts/run_embedding.py
@@ -99,5 +99,6 @@ async def main() -> None:
     print(f"Embedding complete. Wrote {VEC_PATH} ({size_mb:.1f} MB)")
 
 
-# run in current event loop (works in notebooks)
-await main()
+# run from the command line
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- make `run_embedding.py` runnable from the command line by wrapping `main()` in a `__main__` block
